### PR TITLE
Add PromptView id, so it can be used for test

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -1082,6 +1082,7 @@ public class MaterialTapTargetPrompt
         public PromptView(final Context context)
         {
             super(context);
+            setId(R.id.material_target_prompt_view);
             /*paddingPaint.setColor(Color.GREEN);
             paddingPaint.setAlpha(100);
             itemPaint.setColor(Color.BLUE);

--- a/library/src/main/res/values/ids.xml
+++ b/library/src/main/res/values/ids.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2017 Samuel Wall
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+  <item name="material_target_prompt_view" type="id"/>
+</resources>


### PR DESCRIPTION
I was trying to create a test on our company App to test that FeatureDiscovery is shown.

But, as text is displayed in canvas, it cannot be asserted by text, and as the view doesn't have a view id, it cannot be asserted by ID.

This PR adds id to `PromptView`