### PR TITLE
Fix to prevent incorrectly positioning of prompt when target view gets removed from window.

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -403,6 +403,22 @@ public class MaterialTapTargetPrompt
                 @Override
                 public void onGlobalLayout()
                 {
+                    if(mTargetView != null)
+                    {
+                        final boolean isTargetAttachedFromWindow;
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
+                        {
+                            isTargetAttachedFromWindow = mTargetView.isAttachedToWindow();
+                        }
+                        else
+                        {
+                            isTargetAttachedFromWindow = mTargetView.getWindowToken() != null;
+                        }
+                        if(!isTargetAttachedFromWindow)
+                        {
+                            return;
+                        }
+                    }
                     updateFocalCentrePosition();
                 }
             };


### PR DESCRIPTION
Fix for _Prompts get incorrect positioned when removing View #76_.

Check target view is attached to a window, before updating the prompt center position.