### PR TITLE
Fix NPE if dismiss() is called before show()

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -208,6 +208,11 @@ public class MaterialTapTargetPrompt
      */
     public void show()
     {
+        if (isStarting())
+        {
+            return;
+        }
+
         mView.mPromptOptions.getResourceFinder().getPromptParentView().addView(mView);
         addGlobalLayoutListener();
         onPromptStateChanged(STATE_REVEALING);
@@ -233,6 +238,11 @@ public class MaterialTapTargetPrompt
         return mState;
     }
 
+    boolean isStarting()
+    {
+        return mState == STATE_REVEALING || mState == STATE_REVEALED;
+    }
+
     boolean isDismissing()
     {
         return mState == STATE_DISMISSING || mState == STATE_FINISHING;
@@ -243,7 +253,7 @@ public class MaterialTapTargetPrompt
         return mState == STATE_DISMISSED || mState == STATE_FINISHED;
     }
 
-    boolean isDone()
+    boolean isComplete()
     {
         return mState == STATE_UNKNOWN || isDismissing() || isDismissed();
     }
@@ -287,7 +297,7 @@ public class MaterialTapTargetPrompt
      */
     public void finish()
     {
-        if (isDone())
+        if (isComplete())
         {
             return;
         }
@@ -329,7 +339,7 @@ public class MaterialTapTargetPrompt
      */
     public void dismiss()
     {
-        if (isDone())
+        if (isComplete())
         {
             return;
         }

--- a/library/src/test/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPromptUnitTest.java
+++ b/library/src/test/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPromptUnitTest.java
@@ -324,6 +324,16 @@ public class MaterialTapTargetPromptUnitTest
         assertTrue(prompt.mView.dispatchKeyEventPreIme(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK)));
     }
 
+    @Test
+    public void dismissBeforeShow() {
+        MaterialTapTargetPrompt prompt = createBuilder(SCREEN_WIDTH, SCREEN_HEIGHT, 0)
+                .setTarget(10, 10)
+                .setPrimaryText("Primary text")
+                .create();
+        prompt.dismiss();
+        prompt.show();
+    }
+
     private MaterialTapTargetPrompt.Builder createBuilder(final int screenWidth,
                                               final int screenHeight, final float primaryTextWidth)
     {


### PR DESCRIPTION
Upgrading to `v2.2+` gives me this crash:
```
11-03 20:50:19.714 19598-19598/com.supercilex.robotscouter.debug E/UncaughtException: java.lang.NullPointerException: Attempt to invoke virtual method 'android.os.LocaleList android.text.TextPaint.getTextLocales()' on a null object reference
                                                                                          at android.text.StaticLayout.generate(StaticLayout.java:608)
                                                                                          at android.text.StaticLayout.<init>(StaticLayout.java:588)
                                                                                          at android.text.StaticLayout.<init>(Unknown Source:0)
                                                                                          at android.text.StaticLayout$Builder.build(StaticLayout.java:399)
                                                                                          at uk.co.samuelwall.materialtaptargetprompt.extras.PromptUtils.createStaticTextLayout(PromptUtils.java:240)
                                                                                          at uk.co.samuelwall.materialtaptargetprompt.extras.PromptText.createTextLayout(PromptText.java:237)
                                                                                          at uk.co.samuelwall.materialtaptargetprompt.extras.PromptText.update(PromptText.java:263)
                                                                                          at uk.co.samuelwall.materialtaptargetprompt.MaterialTapTargetPrompt.updateAnimation(MaterialTapTargetPrompt.java:473)
                                                                                          at uk.co.samuelwall.materialtaptargetprompt.MaterialTapTargetPrompt$5.onAnimationUpdate(MaterialTapTargetPrompt.java:311)
                                                                                          at android.animation.ValueAnimator.animateValue(ValueAnimator.java:1522)
                                                                                          at android.animation.ValueAnimator.setCurrentFraction(ValueAnimator.java:654)
                                                                                          at android.animation.ValueAnimator.setCurrentPlayTime(ValueAnimator.java:617)
                                                                                          at android.animation.ValueAnimator.start(ValueAnimator.java:1046)
                                                                                          at android.animation.ValueAnimator.start(ValueAnimator.java:1065)
                                                                                          at uk.co.samuelwall.materialtaptargetprompt.MaterialTapTargetPrompt.dismiss(MaterialTapTargetPrompt.java:328)
                                                                                          at com.supercilex.robotscouter.util.ui.TutorialUtilsKt$showAddTeamTutorial$1.onChanged(TutorialUtils.kt:42)
                                                                                          at com.supercilex.robotscouter.util.ui.TutorialUtilsKt$showAddTeamTutorial$1.onChanged(TutorialUtils.kt:21)
                                                                                          at android.arch.lifecycle.LiveData.considerNotify(LiveData.java:131)
                                                                                          at android.arch.lifecycle.LiveData.dispatchingValue(LiveData.java:148)
                                                                                          at android.arch.lifecycle.LiveData.setValue(LiveData.java:294)
                                                                                          at android.arch.lifecycle.MutableLiveData.setValue(MutableLiveData.java:33)
                                                                                          at com.supercilex.robotscouter.util.data.UniqueMutableLiveData.setValue(DatabaseUtils.kt:167)
                                                                                          at com.supercilex.robotscouter.ui.teamlist.TutorialHelper.onDataChanged(TutorialHelper.kt:45)
                                                                                          at com.firebase.ui.common.BaseObservableSnapshotArray.notifyOnDataChanged(BaseObservableSnapshotArray.java:163)
                                                                                          at com.firebase.ui.firestore.FirestoreArray.onEvent(FirestoreArray.java:92)
                                                                                          at com.firebase.ui.firestore.FirestoreArray.onEvent(FirestoreArray.java:21)
                                                                                          at com.google.firebase.firestore.zzi.onEvent(Unknown Source:16)
                                                                                          at com.google.android.gms.internal.zzejz.zza(Unknown Source:6)
                                                                                          at com.google.android.gms.internal.zzeka.run(Unknown Source:6)
                                                                                          at android.os.Handler.handleCallback(Handler.java:790)
                                                                                          at android.os.Handler.dispatchMessage(Handler.java:99)
                                                                                          at android.os.Looper.loop(Looper.java:164)
                                                                                          at android.app.ActivityThread.main(ActivityThread.java:6494)
                                                                                          at java.lang.reflect.Method.invoke(Native Method)
                                                                                          at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
                                                                                          at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```

I have a database listener which only knows if a user has tapped a prompt or not. I use an observable model that shows or dismisses the prompt based on that boolean flag. Thus, I have no knowledge of the current state of the prompt, just the state it should be in. This means I'll be possibly calling `dismiss()` before `show()` which causes the above NPE.

To fix this problem, we now save our current state instead of the limited `mDismissing` field. In addition, I've added a `getState()` method though that isn't necessary to fix the bug.