### PR TITLE
Fix ISE when trying to show prompt while it's dismissing

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -33,6 +33,7 @@ import android.os.Build;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 
 import uk.co.samuelwall.materialtaptargetprompt.extras.PromptOptions;
@@ -212,12 +213,15 @@ public class MaterialTapTargetPrompt
         {
             return;
         }
-        else if (isDismissing())
+
+        final ViewGroup parent = mView.mPromptOptions.getResourceFinder().getPromptParentView();
+
+        if (isDismissing() || parent.findViewById(R.id.material_target_prompt_view) != null)
         {
             cleanUpPrompt(mState);
         }
 
-        mView.mPromptOptions.getResourceFinder().getPromptParentView().addView(mView);
+        parent.addView(mView);
         addGlobalLayoutListener();
         onPromptStateChanged(STATE_REVEALING);
         prepare();

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -212,6 +212,10 @@ public class MaterialTapTargetPrompt
         {
             return;
         }
+        else if (isDismissing())
+        {
+            cleanUpPrompt(mState);
+        }
 
         mView.mPromptOptions.getResourceFinder().getPromptParentView().addView(mView);
         addGlobalLayoutListener();
@@ -342,12 +346,6 @@ public class MaterialTapTargetPrompt
             {
                 cleanUpPrompt(STATE_FINISHED);
             }
-
-            @Override
-            public void onAnimationCancel(Animator animation)
-            {
-                cleanUpPrompt(STATE_FINISHED);
-            }
         });
         mAnimationCurrent.start();
     }
@@ -381,12 +379,6 @@ public class MaterialTapTargetPrompt
         {
             @Override
             public void onAnimationEnd(Animator animation)
-            {
-                cleanUpPrompt(STATE_DISMISSED);
-            }
-
-            @Override
-            public void onAnimationCancel(Animator animation)
             {
                 cleanUpPrompt(STATE_DISMISSED);
             }
@@ -460,14 +452,6 @@ public class MaterialTapTargetPrompt
                     startIdleAnimations();
                 }
                 onPromptStateChanged(STATE_REVEALED);
-            }
-
-            @Override
-            public void onAnimationCancel(Animator animation)
-            {
-                animation.removeAllListeners();
-                updateAnimation(1, 1);
-                cleanUpAnimation();
             }
         });
         mAnimationCurrent.start();

--- a/library/src/test/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPromptUnitTest.java
+++ b/library/src/test/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPromptUnitTest.java
@@ -345,13 +345,25 @@ public class MaterialTapTargetPromptUnitTest
     }
 
     @Test
-    public void dismissBeforeShow() {
+    public void testDismissBeforeShow() {
         MaterialTapTargetPrompt prompt = createBuilder(SCREEN_WIDTH, SCREEN_HEIGHT, 0)
                 .setTarget(10, 10)
                 .setPrimaryText("Primary text")
                 .create();
         prompt.dismiss();
         prompt.show();
+    }
+
+    @Test
+    public void testShowWhileDismissing() {
+        MaterialTapTargetPrompt prompt = createBuilder(SCREEN_WIDTH, SCREEN_HEIGHT, 0)
+                .setTarget(10, 10)
+                .setPrimaryText("Primary text")
+                .create();
+        prompt.show();
+        prompt.dismiss();
+        prompt.show();
+        assertTrue(prompt.isStarting());
     }
 
     private MaterialTapTargetPrompt.Builder createBuilder(final int screenWidth,


### PR DESCRIPTION
Similar to #87, but this time the `ViewGroup` would blow up saying the prompt view was already added. This PR hardens the `show()` method even further to reset the prompt if it's currently dismissing.

In addition, it removes broken `onAnimationCancel` methods. The animator lifecycle guarantees that `onAnimationEnd` will be called even if `onAnimationCancel` is also called.