### PR TITLE
Fix prompt not updating its position

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -110,7 +110,12 @@ public class MaterialTapTargetPrompt
     @Nullable ValueAnimator mAnimationCurrent;
 
     /**
-     * Used to calculate the animation progress for the idle animation.
+     * Used to calculate the animation progress for the idle breathing focal animation.
+     */
+    @Nullable ValueAnimator mAnimationFocalBreathing;
+
+    /**
+     * Used to calculate the animation progress for the idle white flash animation.
      */
     @Nullable ValueAnimator mAnimationFocalRipple;
 
@@ -203,6 +208,12 @@ public class MaterialTapTargetPrompt
                     }
                 }
                 prepare();
+
+                if (mAnimationCurrent == null)
+                {
+                    // Force a relayout to update the view's location
+                    updateAnimation(1, 1);
+                }
             }
         };
     }
@@ -425,6 +436,12 @@ public class MaterialTapTargetPrompt
             mAnimationFocalRipple.cancel();
             mAnimationFocalRipple = null;
         }
+        if (mAnimationFocalBreathing != null)
+        {
+            mAnimationFocalBreathing.removeAllUpdateListeners();
+            mAnimationFocalBreathing.cancel();
+            mAnimationFocalBreathing = null;
+        }
     }
 
     /**
@@ -470,12 +487,12 @@ public class MaterialTapTargetPrompt
     void startIdleAnimations()
     {
         cleanUpAnimation();
-        mAnimationCurrent = ValueAnimator.ofFloat(1, 1.1f, 1);
-        mAnimationCurrent.setInterpolator(mView.mPromptOptions.getAnimationInterpolator());
-        mAnimationCurrent.setDuration(1000);
-        mAnimationCurrent.setStartDelay(225);
-        mAnimationCurrent.setRepeatCount(ValueAnimator.INFINITE);
-        mAnimationCurrent.addUpdateListener(new ValueAnimator.AnimatorUpdateListener()
+        mAnimationFocalBreathing = ValueAnimator.ofFloat(1, 1.1f, 1);
+        mAnimationFocalBreathing.setInterpolator(mView.mPromptOptions.getAnimationInterpolator());
+        mAnimationFocalBreathing.setDuration(1000);
+        mAnimationFocalBreathing.setStartDelay(225);
+        mAnimationFocalBreathing.setRepeatCount(ValueAnimator.INFINITE);
+        mAnimationFocalBreathing.addUpdateListener(new ValueAnimator.AnimatorUpdateListener()
         {
             boolean direction = true;
 
@@ -502,7 +519,7 @@ public class MaterialTapTargetPrompt
                 mView.invalidate();
             }
         });
-        mAnimationCurrent.start();
+        mAnimationFocalBreathing.start();
 
         mAnimationFocalRipple = ValueAnimator.ofFloat(1.1f, 1.6f);
         mAnimationFocalRipple.setInterpolator(mView.mPromptOptions.getAnimationInterpolator());
@@ -522,7 +539,7 @@ public class MaterialTapTargetPrompt
      * Updates the positioning and alpha values using the animation values.
      *
      * @param revealModifier The amount to modify the reveal size, between 0 and 1.
-     * @param alphaModifier The amount to modify the alpha value, between 0 and 1.
+     * @param alphaModifier  The amount to modify the alpha value, between 0 and 1.
      */
     void updateAnimation(final float revealModifier, final float alphaModifier)
     {

--- a/library/src/test/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPromptUnitTest.java
+++ b/library/src/test/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPromptUnitTest.java
@@ -80,7 +80,7 @@ public class MaterialTapTargetPromptUnitTest
                 .setTarget(10, 10)
                 .setPrimaryText("Primary text")
                 .show();
-        prompt.mAnimationCurrent.cancel();
+        prompt.cleanUpAnimation();
         //assertEquals(1f, prompt.mRevealedAmount, 0f);
 
         prompt.dismiss();


### PR DESCRIPTION
This redoes fddc186ce7ba148134e9187216b463239e4574a7 but without #94. The problem was that `animationCurrent` could have greater than `1f` values.