### PR TITLE
Clip PromptFocal drawing area before drawing PromptBackground

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -28,6 +28,7 @@ import android.graphics.Point;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.graphics.Region;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.NonNull;
@@ -710,7 +711,10 @@ public class MaterialTapTargetPrompt
             }
 
             //Draw the backgrounds
+            canvas.save();
+            canvas.clipPath(mPromptOptions.getPromptFocal().getPath(), Region.Op.DIFFERENCE);
             mPromptOptions.getPromptBackground().draw(canvas);
+            canvas.restore();
 
             //Draw the focal
             mPromptOptions.getPromptFocal().draw(canvas);

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -24,6 +24,7 @@ import android.app.DialogFragment;
 import android.app.Fragment;
 import android.content.Context;
 import android.graphics.Canvas;
+import android.graphics.Path;
 import android.graphics.Point;
 import android.graphics.PointF;
 import android.graphics.Rect;
@@ -710,11 +711,20 @@ public class MaterialTapTargetPrompt
                 canvas.clipRect(mClipBounds);
             }
 
-            //Draw the backgrounds
-            canvas.save();
-            canvas.clipPath(mPromptOptions.getPromptFocal().getPath(), Region.Op.DIFFERENCE);
+            //Draw the backgrounds, clipping the focal path so we don't draw over it.
+            final Path focalPath = mPromptOptions.getPromptFocal().getPath();
+            if (focalPath != null)
+            {
+                canvas.save();
+                canvas.clipPath(focalPath, Region.Op.DIFFERENCE);
+            }
+
             mPromptOptions.getPromptBackground().draw(canvas);
-            canvas.restore();
+
+            if (focalPath != null)
+            {
+                canvas.restore();
+            }
 
             //Draw the focal
             mPromptOptions.getPromptFocal().draw(canvas);

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptFocal.java
@@ -16,6 +16,7 @@
 
 package uk.co.samuelwall.materialtaptargetprompt.extras;
 
+import android.graphics.Path;
 import android.graphics.RectF;
 import android.support.annotation.ColorInt;
 import android.support.annotation.FloatRange;
@@ -71,6 +72,13 @@ public abstract class PromptFocal implements PromptUIElement
      */
     @NonNull
     public abstract RectF getBounds();
+
+    /**
+     * Get the focal path to be drawn.
+     * @return The path used to draw the focal
+     */
+    @NonNull
+    public abstract Path getPath();
 
     /**
      * Setup the focal ready for rendering when targeting a view, called prior to first render.

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptFocal.java
@@ -60,6 +60,14 @@ public abstract class PromptFocal implements PromptUIElement
     }
 
     /**
+     * Get the focal path to be drawn. Override this to support a transparent focal colour.
+     * @return The path used to draw the focal
+     */
+    public Path getPath() {
+        return null;
+    }
+
+    /**
      * Set the focal colour.
      *
      * @param colour Int colour.
@@ -72,13 +80,6 @@ public abstract class PromptFocal implements PromptUIElement
      */
     @NonNull
     public abstract RectF getBounds();
-
-    /**
-     * Get the focal path to be drawn.
-     * @return The path used to draw the focal
-     */
-    @NonNull
-    public abstract Path getPath();
 
     /**
      * Setup the focal ready for rendering when targeting a view, called prior to first render.

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/CirclePromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/CirclePromptFocal.java
@@ -43,6 +43,7 @@ public class CirclePromptFocal extends PromptFocal
     int mBaseAlpha;
     PointF mPosition;
     RectF mBounds;
+    Path mPath;
 
     /**
      * Constructor.
@@ -79,9 +80,7 @@ public class CirclePromptFocal extends PromptFocal
     @Override
     public Path getPath()
     {
-        final Path path = new Path();
-        path.addCircle(mPosition.x, mPosition.y, mRadius, Path.Direction.CW);
-        return path;
+        return mPath;
     }
 
     @Override
@@ -111,6 +110,9 @@ public class CirclePromptFocal extends PromptFocal
         mBounds.top = targetY - mBaseRadius;
         mBounds.right = targetX + mBaseRadius;
         mBounds.bottom = targetY + mBaseRadius;
+
+        mPath = new Path();
+        mPath.addCircle(mPosition.x, mPosition.y, mBaseRadius, Path.Direction.CW);
     }
 
     @Override

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/CirclePromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/CirclePromptFocal.java
@@ -110,9 +110,6 @@ public class CirclePromptFocal extends PromptFocal
         mBounds.top = targetY - mBaseRadius;
         mBounds.right = targetX + mBaseRadius;
         mBounds.bottom = targetY + mBaseRadius;
-
-        mPath = new Path();
-        mPath.addCircle(mPosition.x, mPosition.y, mBaseRadius, Path.Direction.CW);
     }
 
     @Override
@@ -121,6 +118,9 @@ public class CirclePromptFocal extends PromptFocal
     {
         mPaint.setAlpha((int) (mBaseAlpha * alphaModifier));
         mRadius = mBaseRadius * revealModifier;
+
+        mPath = new Path();
+        mPath.addCircle(mPosition.x, mPosition.y, mRadius, Path.Direction.CW);
     }
 
     @Override

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/CirclePromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/CirclePromptFocal.java
@@ -19,6 +19,7 @@ package uk.co.samuelwall.materialtaptargetprompt.extras.focals;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.Path;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.support.annotation.ColorInt;
@@ -72,6 +73,15 @@ public class CirclePromptFocal extends PromptFocal
     public RectF getBounds()
     {
         return mBounds;
+    }
+
+    @NonNull
+    @Override
+    public Path getPath()
+    {
+        final Path path = new Path();
+        path.addCircle(mPosition.x, mPosition.y, mRadius, Path.Direction.CW);
+        return path;
     }
 
     @Override
@@ -132,7 +142,7 @@ public class CirclePromptFocal extends PromptFocal
 
         // canvas.drawRect(mBounds, mPaint);
 
-        canvas.drawCircle(mPosition.x, mPosition.y, mRadius, mPaint);
+        canvas.drawPath(getPath(), mPaint);
     }
 
     @Override

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/CirclePromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/CirclePromptFocal.java
@@ -137,8 +137,11 @@ public class CirclePromptFocal extends PromptFocal
         if (mDrawRipple)
         {
             final int oldAlpha = mPaint.getAlpha();
+            final int oldColor = mPaint.getColor();
+            mPaint.setColor(Color.WHITE);
             mPaint.setAlpha(mRippleAlpha);
             canvas.drawCircle(mPosition.x, mPosition.y, mRippleRadius, mPaint);
+            mPaint.setColor(oldColor);
             mPaint.setAlpha(oldAlpha);
         }
 

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/CirclePromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/CirclePromptFocal.java
@@ -138,7 +138,10 @@ public class CirclePromptFocal extends PromptFocal
         {
             final int oldAlpha = mPaint.getAlpha();
             final int oldColor = mPaint.getColor();
-            mPaint.setColor(Color.WHITE);
+            if (oldColor == Color.TRANSPARENT)
+            {
+                mPaint.setColor(Color.WHITE);
+            }
             mPaint.setAlpha(mRippleAlpha);
             canvas.drawCircle(mPosition.x, mPosition.y, mRippleRadius, mPaint);
             mPaint.setColor(oldColor);

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/RectanglePromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/RectanglePromptFocal.java
@@ -47,6 +47,7 @@ public class RectanglePromptFocal extends PromptFocal
     RectF mRippleBounds;
     int mBaseAlpha;
     float mPadding;
+    Path mPath;
     private float mRx, mRy;
     @Nullable private PointF mSize;
 
@@ -130,9 +131,7 @@ public class RectanglePromptFocal extends PromptFocal
     @Override
     public Path getPath()
     {
-        final Path path = new Path();
-        path.addRoundRect(mBounds, mRx, mRy, Path.Direction.CW);
-        return path;
+        return mPath;
     }
 
     @Override
@@ -160,6 +159,9 @@ public class RectanglePromptFocal extends PromptFocal
             mBaseBounds.bottom = top + height + mPadding;
             mBaseBoundsCentre.x = left + (width / 2);
             mBaseBoundsCentre.y = top + (height / 2);
+
+            mPath = new Path();
+            mPath.addRoundRect(mBaseBounds, mRx, mRy, Path.Direction.CW);
         }
         else
         {
@@ -180,6 +182,9 @@ public class RectanglePromptFocal extends PromptFocal
             mBaseBounds.bottom = targetY + halfHeight + mPadding;
             mBaseBoundsCentre.x = targetX;
             mBaseBoundsCentre.y = targetY;
+
+            mPath = new Path();
+            mPath.addRoundRect(mBaseBounds, mRx, mRy, Path.Direction.CW);
         }
         else
         {

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/RectanglePromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/RectanglePromptFocal.java
@@ -159,9 +159,6 @@ public class RectanglePromptFocal extends PromptFocal
             mBaseBounds.bottom = top + height + mPadding;
             mBaseBoundsCentre.x = left + (width / 2);
             mBaseBoundsCentre.y = top + (height / 2);
-
-            mPath = new Path();
-            mPath.addRoundRect(mBaseBounds, mRx, mRy, Path.Direction.CW);
         }
         else
         {
@@ -182,9 +179,6 @@ public class RectanglePromptFocal extends PromptFocal
             mBaseBounds.bottom = targetY + halfHeight + mPadding;
             mBaseBoundsCentre.x = targetX;
             mBaseBoundsCentre.y = targetY;
-
-            mPath = new Path();
-            mPath.addRoundRect(mBaseBounds, mRx, mRy, Path.Direction.CW);
         }
         else
         {
@@ -197,6 +191,9 @@ public class RectanglePromptFocal extends PromptFocal
                        float alphaModifier)
     {
         PromptUtils.scale(mBaseBoundsCentre, mBaseBounds, mBounds, revealModifier, true);
+
+        mPath = new Path();
+        mPath.addRoundRect(mBounds, mRx, mRy, Path.Direction.CW);
     }
 
     @Override

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/RectanglePromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/RectanglePromptFocal.java
@@ -20,6 +20,7 @@ import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.Path;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.support.annotation.ColorInt;
@@ -125,6 +126,15 @@ public class RectanglePromptFocal extends PromptFocal
         return mBaseBounds;
     }
 
+    @NonNull
+    @Override
+    public Path getPath()
+    {
+        final Path path = new Path();
+        path.addRoundRect(mBounds, mRx, mRy, Path.Direction.CW);
+        return path;
+    }
+
     @Override
     public void setColour(@ColorInt int colour)
     {
@@ -203,7 +213,7 @@ public class RectanglePromptFocal extends PromptFocal
             mPaint.setAlpha(oldAlpha);
         }
 
-        canvas.drawRoundRect(mBounds, mRx, mRy, mPaint);
+        canvas.drawPath(getPath(), mPaint);
 
         // canvas.drawRoundRect(mBaseBounds, mRx, mRy, mBoundsPaint);
     }

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/RectanglePromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/RectanglePromptFocal.java
@@ -213,8 +213,11 @@ public class RectanglePromptFocal extends PromptFocal
         if (mDrawRipple)
         {
             final int oldAlpha = mPaint.getAlpha();
+            final int oldColor = mPaint.getColor();
+            mPaint.setColor(Color.WHITE);
             mPaint.setAlpha(mRippleAlpha);
             canvas.drawRoundRect(mRippleBounds, mRx, mRy, mPaint);
+            mPaint.setColor(oldColor);
             mPaint.setAlpha(oldAlpha);
         }
 

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/RectanglePromptFocal.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/focals/RectanglePromptFocal.java
@@ -214,7 +214,10 @@ public class RectanglePromptFocal extends PromptFocal
         {
             final int oldAlpha = mPaint.getAlpha();
             final int oldColor = mPaint.getColor();
-            mPaint.setColor(Color.WHITE);
+            if (oldColor == Color.TRANSPARENT)
+            {
+                mPaint.setColor(Color.WHITE);
+            }
             mPaint.setAlpha(mRippleAlpha);
             canvas.drawRoundRect(mRippleBounds, mRx, mRy, mPaint);
             mPaint.setColor(oldColor);


### PR DESCRIPTION
This allows setting `MaterialTapTargetPrompt.Builder.setFocalColour(Color.TRANSPARENT)` to make the contents of the view behind the MaterialTapTargetPrompt show through the PromptFocal.
