### PR TITLE
Fix memory leak when prompt isn't explicitly dismissed

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -188,6 +188,7 @@ public class MaterialTapTargetPrompt
     {
         final ResourceFinder resourceFinder = promptOptions.getResourceFinder();
         mView = new PromptView(resourceFinder.getContext());
+        mView.mPrompt = this;
         mView.mPromptOptions = promptOptions;
         mView.mPromptTouchedListener = new PromptView.PromptTouchedListener()
         {
@@ -749,6 +750,7 @@ public class MaterialTapTargetPrompt
         PromptTouchedListener mPromptTouchedListener;
         Rect mClipBounds = new Rect();
         View mTargetRenderView;
+        MaterialTapTargetPrompt mPrompt;
         PromptOptions mPromptOptions;
         boolean mClipToBounds;
 
@@ -885,6 +887,13 @@ public class MaterialTapTargetPrompt
             }
 
             return super.dispatchKeyEventPreIme(event);
+        }
+
+        @Override
+        protected void onDetachedFromWindow()
+        {
+            super.onDetachedFromWindow();
+            mPrompt.cleanUpAnimation();
         }
 
         /**

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -44,7 +44,10 @@ dependencies {
 
     implementation 'com.android.support:design:' + rootProject.supportLibVersion
     implementation 'com.android.support:cardview-v7:' + rootProject.supportLibVersion
-
     implementation 'com.android.support.constraint:constraint-layout:1.1.0'
+
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
+    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
+
     testImplementation 'junit:junit:4.12'
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
           package="uk.co.samuelwall.materialtaptargetprompt.sample">
 
     <application
+        android:name=".Mttp"
         android:label="@string/app_name"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/sample/src/main/java/uk/co/samuelwall/materialtaptargetprompt/sample/Mttp.java
+++ b/sample/src/main/java/uk/co/samuelwall/materialtaptargetprompt/sample/Mttp.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016-2018 Samuel Wall
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.co.samuelwall.materialtaptargetprompt.sample;
+
+import android.app.Application;
+
+import com.squareup.leakcanary.LeakCanary;
+
+public class Mttp extends Application
+{
+    @Override
+    public void onCreate()
+    {
+        super.onCreate();
+        if (!LeakCanary.isInAnalyzerProcess(this))
+        {
+            LeakCanary.install(this);
+        }
+    }
+}


### PR DESCRIPTION
The animation listener doesn't die with the view apparently (which leaks it).