### PR TITLE
Update CirclePromptBackground way to measure

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/CirclePromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/CirclePromptBackground.java
@@ -176,9 +176,9 @@ public class CirclePromptBackground extends PromptBackground
             mBasePosition.set(focalCentreX, focalCentreY);
            // Calculate the furthest distance from the center based on the text size.
             final float length = Math.max(
-                    Math.abs(textBounds.right - focalBounds.centerX()),
-                    Math.abs(textBounds.left - focalBounds.centerX())
-            ) + textPadding + focalBounds.width() / 2f
+                    Math.abs(textBounds.right - focalCentreX),
+                    Math.abs(textBounds.left - focalCentreX)
+            ) + textPadding + focalBounds.width() / 2f;
             // Calculate the height based on the distance from the focal centre to the furthest text y position.
             float height = (focalBounds.height() / 2) + focalPadding + textBounds.height();
             // Calculate the radius based on the calculated width and height

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/CirclePromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/CirclePromptBackground.java
@@ -174,12 +174,11 @@ public class CirclePromptBackground extends PromptBackground
         else
         {
             mBasePosition.set(focalCentreX, focalCentreY);
-            // Calculate the furthest distance from the a focal side to a text side.
-            final float length = Math.abs(
-                    (textBounds.left < focalBounds.left ?
-                            textBounds.left - textPadding
-                            : textBounds.right + textPadding)
-                    - focalCentreX);
+           // Calculate the furthest distance from the center based on the text size.
+            final float length = Math.max(
+                    Math.abs(textBounds.right - focalBounds.centerX()),
+                    Math.abs(textBounds.left - focalBounds.centerX())
+            ) + textPadding + focalBounds.width() / 2f
             // Calculate the height based on the distance from the focal centre to the furthest text y position.
             float height = (focalBounds.height() / 2) + focalPadding + textBounds.height();
             // Calculate the radius based on the calculated width and height


### PR DESCRIPTION
Change the way that CirclePromptBackground measures the further distance to calculate the height and the radius of the Circle view.

The only change have been modify that it was done, making it easier calculating it based on the center of the screen and the textSize + Padding. Because there was some weird cases were the calcule was wrong