### PR TITLE
Add some TalkBack accessibility support

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -18,7 +18,6 @@ package uk.co.samuelwall.materialtaptargetprompt;
 
 import android.animation.Animator;
 import android.animation.ValueAnimator;
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
@@ -33,22 +32,17 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
-import android.support.v4.view.AccessibilityDelegateCompat;
-import android.support.v4.view.ViewCompat;
 import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewParent;
 import android.view.ViewTreeObserver;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeInfo;
-import android.view.accessibility.AccessibilityNodeProvider;
 
 import uk.co.samuelwall.materialtaptargetprompt.extras.PromptOptions;
 
@@ -770,6 +764,10 @@ public class MaterialTapTargetPrompt
 
             setAccessibilityDelegate(new AccessibilityDelegate());
             mAccessibilityManager = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
+
+            if (mAccessibilityManager.isEnabled()) {
+                setClickable(true);
+            }
         }
 
         @Override
@@ -929,6 +927,34 @@ public class MaterialTapTargetPrompt
         }
 
         class AccessibilityDelegate extends View.AccessibilityDelegate {
+
+            @Override
+            public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfo info)
+            {
+                super.onInitializeAccessibilityNodeInfo(host, info);
+
+                info.setClassName(PromptView.this.getClass().getName());
+                info.setPackageName(PromptView.this.getClass().getPackage().getName());
+                info.setSource(host);
+                info.setClickable(true);
+                info.setEnabled(true);
+                info.setChecked(false);
+                info.setFocusable(true);
+                info.setFocused(true);
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+                {
+                    info.setLabelFor(mPromptOptions.getTargetView());
+                }
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
+                {
+                    info.setDismissable(true);
+                }
+
+                info.setContentDescription(String.format("%s. %s", mPromptOptions.getPrimaryText(), mPromptOptions.getSecondaryText()));
+                info.setText(String.format("%s. %s", mPromptOptions.getPrimaryText(), mPromptOptions.getSecondaryText()));
+            }
 
             @Override
             public void onPopulateAccessibilityEvent(View host, AccessibilityEvent event)

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -18,6 +18,7 @@ package uk.co.samuelwall.materialtaptargetprompt;
 
 import android.animation.Animator;
 import android.animation.ValueAnimator;
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
@@ -32,13 +33,22 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
+import android.support.v4.view.AccessibilityDelegateCompat;
+import android.support.v4.view.ViewCompat;
+import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.view.ViewTreeObserver;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityManager;
+import android.view.accessibility.AccessibilityNodeInfo;
+import android.view.accessibility.AccessibilityNodeProvider;
 
 import uk.co.samuelwall.materialtaptargetprompt.extras.PromptOptions;
 
@@ -405,6 +415,7 @@ public class MaterialTapTargetPrompt
             public void onAnimationEnd(Animator animation)
             {
                 cleanUpPrompt(STATE_FINISHED);
+                mView.sendAccessibilityEvent(AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
             }
         });
         onPromptStateChanged(STATE_FINISHING);
@@ -442,6 +453,7 @@ public class MaterialTapTargetPrompt
             public void onAnimationEnd(Animator animation)
             {
                 cleanUpPrompt(STATE_DISMISSED);
+                mView.sendAccessibilityEvent(AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
             }
         });
         onPromptStateChanged(STATE_DISMISSING);
@@ -520,6 +532,9 @@ public class MaterialTapTargetPrompt
                     startIdleAnimations();
                 }
                 onPromptStateChanged(STATE_REVEALED);
+
+                mView.requestFocus();
+                mView.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
             }
         });
         mAnimationCurrent.start();
@@ -729,6 +744,7 @@ public class MaterialTapTargetPrompt
         MaterialTapTargetPrompt mPrompt;
         PromptOptions mPromptOptions;
         boolean mClipToBounds;
+        AccessibilityManager mAccessibilityManager;
 
         /**
          * Create a new prompt view.
@@ -751,6 +767,9 @@ public class MaterialTapTargetPrompt
             paddingPaint.setAlpha(100);
             itemPaint.setColor(Color.BLUE);
             itemPaint.setAlpha(100);*/
+
+            setAccessibilityDelegate(new AccessibilityDelegate());
+            mAccessibilityManager = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
         }
 
         @Override
@@ -799,6 +818,26 @@ public class MaterialTapTargetPrompt
 
             //Draw the text
             mPromptOptions.getPromptText().draw(canvas);
+        }
+
+        @Override
+        public boolean onHoverEvent(MotionEvent event) {
+            if (mAccessibilityManager.isTouchExplorationEnabled() && event.getPointerCount() == 1) {
+                final int action = event.getAction();
+                switch (action) {
+                    case MotionEvent.ACTION_HOVER_ENTER: {
+                        event.setAction(MotionEvent.ACTION_DOWN);
+                    } break;
+                    case MotionEvent.ACTION_HOVER_MOVE: {
+                        event.setAction(MotionEvent.ACTION_MOVE);
+                    } break;
+                    case MotionEvent.ACTION_HOVER_EXIT: {
+                        event.setAction(MotionEvent.ACTION_UP);
+                    } break;
+                }
+                return onTouchEvent(event);
+            }
+            return super.onHoverEvent(event);
         }
 
         @Override
@@ -887,6 +926,27 @@ public class MaterialTapTargetPrompt
              * pressed.
              */
             void onNonFocalPressed();
+        }
+
+        class AccessibilityDelegate extends View.AccessibilityDelegate {
+
+            @Override
+            public void onPopulateAccessibilityEvent(View host, AccessibilityEvent event)
+            {
+                super.onPopulateAccessibilityEvent(host, event);
+
+                final CharSequence primary = mPromptOptions.getPrimaryText();
+                if (!TextUtils.isEmpty(primary))
+                {
+                    event.getText().add(primary);
+                }
+
+                final CharSequence secondary = mPromptOptions.getSecondaryText();
+                if (!TextUtils.isEmpty(secondary))
+                {
+                    event.getText().add(secondary);
+                }
+            }
         }
     }
 

--- a/library/src/test/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPromptUnitTest.java
+++ b/library/src/test/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPromptUnitTest.java
@@ -27,6 +27,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewParent;
+import android.view.accessibility.AccessibilityEvent;
 import android.widget.Button;
 import android.widget.FrameLayout;
 
@@ -37,14 +38,23 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.AccessibilityUtil;
+import org.robolectric.annotation.AccessibilityChecks;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.ReflectionHelpers;
 
 import uk.co.samuelwall.materialtaptargetprompt.extras.PromptFocal;
 import uk.co.samuelwall.materialtaptargetprompt.extras.PromptOptions;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = uk.co.samuelwall.materialtaptargetprompt.BuildConfig.class, sdk = 22)
@@ -874,6 +884,23 @@ public class MaterialTapTargetPromptUnitTest extends BaseTestStateProgress
         assertNotNull(prompt);
         prompt.show();
         assertNull(prompt.mAnimationFocalBreathing);
+    }
+
+    @Test
+    @AccessibilityChecks
+    public void testPromptAccessibility() {
+        MaterialTapTargetPrompt prompt = createMockBuilder(SCREEN_WIDTH, SCREEN_HEIGHT)
+                .setTarget(10, 10)
+                .setPrimaryText("Primary text")
+                .setIdleAnimationEnabled(false)
+                .create();
+        assertNotNull(prompt);
+        prompt.show();
+
+        AccessibilityUtil.setThrowExceptionForErrors(true);
+        AccessibilityUtil.checkView(prompt.mView);
+
+        prompt.mView.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
     }
     
     private MaterialTapTargetPrompt.Builder createMockBuilder(final int screenWidth,


### PR DESCRIPTION
When prompt is opened TalkBack service will speak loud the primary text if any followed by the secondary text when exist.

When accessibility is enabled with touch exploration we prevent selecting views behind the prompt when it is shown.

This should close #126 