### PR TITLE
Added immersive compat rectangle background

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/FullscreenPromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/FullscreenPromptBackground.java
@@ -82,11 +82,16 @@ public class FullscreenPromptBackground extends PromptBackground
     public void prepare(@NonNull final PromptOptions options, final boolean clipToBounds, @NonNull Rect clipBounds)
     {
         final RectF focalBounds = options.getPromptFocal().getBounds();
-        DisplayMetrics metrics = Resources.getSystem().getDisplayMetrics();
+        DisplayMetrics metrics = getDisplayMetrics();
 
         mBaseBounds.set(0, 0, metrics.widthPixels, metrics.heightPixels);
         mFocalCentre.x = focalBounds.centerX();
         mFocalCentre.y = focalBounds.centerY();
+    }
+
+    @NonNull
+    protected DisplayMetrics getDisplayMetrics() {
+        return Resources.getSystem().getDisplayMetrics();
     }
 
     @Override

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/ImmersiveCompatPromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/ImmersiveCompatPromptBackground.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016-2018 Samuel Wall
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.co.samuelwall.materialtaptargetprompt.extras.backgrounds;
+
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.util.DisplayMetrics;
+import android.view.Display;
+import android.view.WindowManager;
+
+public class ImmersiveCompatPromptBackground extends FullscreenPromptBackground
+{
+    @NonNull
+    private final DisplayMetrics mBaseMetrics;
+    @NonNull
+    private final WindowManager mWindowManager;
+
+    public ImmersiveCompatPromptBackground(@NonNull WindowManager windowManager) {
+        this.mWindowManager = windowManager;
+        mBaseMetrics = new DisplayMetrics();
+    }
+
+    @NonNull
+    @Override
+    protected DisplayMetrics getDisplayMetrics() {
+        Display defaultDisplay = mWindowManager.getDefaultDisplay();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            defaultDisplay.getRealMetrics(mBaseMetrics);
+        } else {
+            defaultDisplay.getMetrics(mBaseMetrics);
+        }
+        return mBaseMetrics;
+    }
+}

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/ImmersiveCompatPromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/ImmersiveCompatPromptBackground.java
@@ -30,7 +30,7 @@ public class ImmersiveCompatPromptBackground extends FullscreenPromptBackground
     private final WindowManager mWindowManager;
 
     public ImmersiveCompatPromptBackground(@NonNull WindowManager windowManager) {
-        this.mWindowManager = windowManager;
+        mWindowManager = windowManager;
         mBaseMetrics = new DisplayMetrics();
     }
 

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/ImmersiveModeCompatPromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/ImmersiveModeCompatPromptBackground.java
@@ -22,14 +22,14 @@ import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.WindowManager;
 
-public class ImmersiveCompatPromptBackground extends FullscreenPromptBackground
+public class ImmersiveModeCompatPromptBackground extends FullscreenPromptBackground
 {
     @NonNull
     private final DisplayMetrics mBaseMetrics;
     @NonNull
     private final WindowManager mWindowManager;
 
-    public ImmersiveCompatPromptBackground(@NonNull WindowManager windowManager) {
+    public ImmersiveModeCompatPromptBackground(@NonNull WindowManager windowManager) {
         mWindowManager = windowManager;
         mBaseMetrics = new DisplayMetrics();
     }

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/ImmersiveModeCompatPromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/ImmersiveModeCompatPromptBackground.java
@@ -22,6 +22,9 @@ import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.WindowManager;
 
+/**
+ * {@link ImmersiveModeCompatPromptBackground} implementation that renders the prompt background as a rectangle for supporting immersive mode.
+ */
 public class ImmersiveModeCompatPromptBackground extends FullscreenPromptBackground
 {
     @NonNull


### PR DESCRIPTION
For samsung 8 or samsung 9 or another device FullScreenPromptBackground drawn above navigation bar when user transit to immersive mode.
E.g here:
before using new Background class - https://s.mail.ru/Fs5b/8NpwtvYtg
after using new Background class - https://cloud.mail.ru/public/KtQi/huG5YMyCo
My code sample https://s.mail.ru/4Fdb/uhhv6Wixd

Please, take a look my pull request. Thank you 