### PR TITLE
accessibility adjustments

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -795,7 +795,7 @@ public class MaterialTapTargetPrompt
             mAccessibilityManager = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
 
             if (mAccessibilityManager.isEnabled()) {
-                setClickable(true);
+                setupAccessibilityClickListener();
             }
         }
 
@@ -950,6 +950,32 @@ public class MaterialTapTargetPrompt
         public CharSequence getAccessibilityClassName()
         {
             return PromptView.class.getName();
+        }
+
+        /**
+         * When AccessibilityManager is enabled, the prompt view can be dismissed by double-tap.
+         * The event is also passed as onClick() to the target view, when available.
+         */
+        private void setupAccessibilityClickListener()
+        {
+            setClickable(true);
+            setOnClickListener(new OnClickListener()
+            {
+                @Override
+                public void onClick(View view)
+                {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1)
+                    {
+                        final View targetView = mPromptOptions.getTargetView();
+                        if (targetView != null)
+                        {
+                            targetView.callOnClick();
+                        }
+                    }
+
+                    mPrompt.finish();
+                }
+            });
         }
 
         /**

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -1003,8 +1003,8 @@ public class MaterialTapTargetPrompt
                     info.setDismissable(true);
                 }
 
-                info.setContentDescription(String.format("%s. %s", mPromptOptions.getPrimaryText(), mPromptOptions.getSecondaryText()));
-                info.setText(String.format("%s. %s", mPromptOptions.getPrimaryText(), mPromptOptions.getSecondaryText()));
+                info.setContentDescription(mPromptOptions.getContentDescription());
+                info.setText(mPromptOptions.getContentDescription());
             }
 
             @Override
@@ -1012,16 +1012,10 @@ public class MaterialTapTargetPrompt
             {
                 super.onPopulateAccessibilityEvent(host, event);
 
-                final CharSequence primary = mPromptOptions.getPrimaryText();
-                if (!TextUtils.isEmpty(primary))
+                final CharSequence contentDescription = mPromptOptions.getContentDescription();
+                if (!TextUtils.isEmpty(contentDescription))
                 {
-                    event.getText().add(primary);
-                }
-
-                final CharSequence secondary = mPromptOptions.getSecondaryText();
-                if (!TextUtils.isEmpty(secondary))
-                {
-                    event.getText().add(secondary);
+                    event.getText().add(contentDescription);
                 }
             }
         }

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptOptions.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptOptions.java
@@ -166,6 +166,7 @@ public class PromptOptions<T extends PromptOptions>
     private boolean mAutoFinish = true;
     private boolean mCaptureTouchEventOutsidePrompt;
     @Nullable private Typeface mPrimaryTextTypeface, mSecondaryTextTypeface;
+    @Nullable private String mContentDescription;
     private int mPrimaryTextTypefaceStyle, mSecondaryTextTypefaceStyle;
     @Nullable private ColorStateList mIconDrawableTintList = null;
     @Nullable private PorterDuff.Mode mIconDrawableTintMode = PorterDuff.Mode.MULTIPLY;
@@ -246,6 +247,7 @@ public class PromptOptions<T extends PromptOptions>
         mSecondaryTextTypefaceStyle = a.getInt(R.styleable.PromptView_mttp_secondaryTextStyle, mSecondaryTextTypefaceStyle);
         mPrimaryTextTypeface = PromptUtils.setTypefaceFromAttrs(a.getString(R.styleable.PromptView_mttp_primaryTextFontFamily), a.getInt(R.styleable.PromptView_mttp_primaryTextTypeface, 0), mPrimaryTextTypefaceStyle);
         mSecondaryTextTypeface = PromptUtils.setTypefaceFromAttrs(a.getString(R.styleable.PromptView_mttp_secondaryTextFontFamily), a.getInt(R.styleable.PromptView_mttp_secondaryTextTypeface, 0), mSecondaryTextTypefaceStyle);
+        mContentDescription = a.getString(R.styleable.PromptView_mttp_contentDescription);
 
         mIconDrawableColourFilter = a.getColor(R.styleable.PromptView_mttp_iconColourFilter, mBackgroundColour);
         mIconDrawableTintList = a.getColorStateList(R.styleable.PromptView_mttp_iconTint);
@@ -699,6 +701,51 @@ public class PromptOptions<T extends PromptOptions>
     public int getSecondaryTextTypefaceStyle()
     {
         return mSecondaryTextTypefaceStyle;
+    }
+
+    /**
+     * Set the accessibility content description text using the given resource id.
+     *
+     * @param resId The string resource id for the accessibility content description text
+     * @return This Builder object to allow for chaining of calls to set methods
+     */
+    @NonNull
+    public T setContentDescription(@StringRes final int resId)
+    {
+        mContentDescription = mResourceFinder.getString(resId);
+        return (T) this;
+    }
+
+    /**
+     * Set the accessibility content description text to the given string
+     *
+     * @param text The accessibility content description text
+     * @return This Builder object to allow for chaining of calls to set methods
+     */
+    @NonNull
+    public T setContentDescription(@Nullable final String text)
+    {
+        mContentDescription = text;
+        return (T) this;
+    }
+
+    /**
+     * Get the text for the accessibility content description.
+     * Defaults to a concatenation of primary and secondary texts.
+     *
+     * @return The accessibility content description text.
+     */
+    @Nullable
+    public String getContentDescription()
+    {
+        if (mContentDescription != null)
+        {
+            return mContentDescription;
+        }
+        else
+        {
+            return String.format("%s. %s", mPrimaryText, mSecondaryText);
+        }
     }
 
     /**

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -59,6 +59,7 @@
         <enum name="serif" value="2" />
         <enum name="monospace" value="3" />
     </attr>
+    <attr name="mttp_contentDescription" format="string"/>
     <attr name="mttp_iconTint" format="reference"/>
     <attr name="mttp_iconTintMode" format="enum">
         <enum name="SRC_OVER" value="3" />
@@ -94,6 +95,7 @@
         <attr name="mttp_secondaryTextStyle"/>
         <attr name="mttp_primaryTextTypeface"/>
         <attr name="mttp_secondaryTextTypeface"/>
+        <attr name="mttp_contentDescription"/>
         <attr name="mttp_iconTint"/>
         <attr name="mttp_iconTintMode"/>
         <attr name="mttp_iconColourFilter"/>

--- a/sample/src/main/java/uk/co/samuelwall/materialtaptargetprompt/sample/MainActivity.java
+++ b/sample/src/main/java/uk/co/samuelwall/materialtaptargetprompt/sample/MainActivity.java
@@ -159,6 +159,7 @@ public class MainActivity extends AppCompatActivity
         final MaterialTapTargetPrompt.Builder tapTargetPromptBuilder = new MaterialTapTargetPrompt.Builder(this)
                 .setPrimaryText(R.string.menu_prompt_title)
                 .setSecondaryText(R.string.menu_prompt_description)
+                .setContentDescription(R.string.menu_prompt_content_description)
                 .setFocalPadding(R.dimen.dp40)
                 .setAnimationInterpolator(new FastOutSlowInInterpolator())
                 .setMaxTextWidth(R.dimen.tap_target_menu_max_width)

--- a/sample/src/main/res/values-en-rUS/strings.xml
+++ b/sample/src/main/res/values-en-rUS/strings.xml
@@ -26,6 +26,7 @@
 
     <string name="menu_prompt_title">Just how you want it</string>
     <string name="menu_prompt_description">Tap the menu icon to switch accounts, change settings &amp; more</string>
+    <string name="menu_prompt_content_description">This is an example of the accessibility content description, tap to exit. Tap the menu icon to switch accounts, change settings &amp; more</string>
 
     <string name="overflow_prompt_title">More actions</string>
     <string name="overflow_prompt_description">Tap the 3 vertical dots to see more options</string>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
 
     <string name="menu_prompt_title">Just how you want it</string>
     <string name="menu_prompt_description">Tap the menu icon to switch accounts, change settings &amp; more</string>
+    <string name="menu_prompt_content_description">This is an example of the accessibility content description, tap to exit. Tap the menu icon to switch accounts, change settings &amp; more</string>
 
     <string name="overflow_prompt_title">More actions</string>
     <string name="overflow_prompt_description">Tap the 3 vertical dots to see more options</string>


### PR DESCRIPTION
Thanks for this beautiful library!
For my project, I needed to have more accessibility support. The main issue is that I need to inform the user that we're in a new view / screen / prompt. So I've added a `setContentDescription()` which defaults to the original primary+secondary.
The other issue is how to handle the double tap (onClick). I'm still a beginner in a11y support, but my personal feeling is that once you tell users "The search button allows you to access more content", it would be strange to send them back to first focusable item of the screen. One would need to navigate  through the UI back to the search button to be able to use the feature they were prompted for.