### PR TITLE
Fix crash on `showFromIndex` in `MaterialTapTargetSequence`

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetSequence.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetSequence.java
@@ -290,6 +290,7 @@ public class MaterialTapTargetSequence
     public MaterialTapTargetSequence showFromIndex(final int index)
     {
         this.dismiss();
+        this.nextPromptIndex = index;
         this.show(index);
         return this;
     }


### PR DESCRIPTION
Hello,
i hit the case where i need to use the `showFromIndex` from `MaterialTapTargetSequence` . After few tests i found out, there is a crash: `IndexOutOfBoundsException` caused by `nextPromptIndex` being `-1` which is it's initial value. After inspecting the code base i saw `nextPromptIndex` is missing initialization when called `showFromIndex`. I'm suggesting a fix for the issue, so `showFromIndex` is now usable. 