### PR TITLE
fix: FragmentContainerView as parent

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/SupportFragmentResourceFinder.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/SupportFragmentResourceFinder.java
@@ -25,6 +25,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 
 /**
  * {@link ResourceFinder} implementation for {@link Fragment}.
@@ -65,6 +66,9 @@ public class SupportFragmentResourceFinder implements ResourceFinder
     {
         if (this.parent == null)
         {
+            ViewParent parent = this.fragment.getView().getParent();
+            while (parent.getClass().getName().contains("FragmentContainerView"))
+                parent = parent.getParent();
             //noinspection ConstantConditions
             this.parent = (ViewGroup) this.fragment.getView().getParent();
         }

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/SupportFragmentResourceFinder.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/SupportFragmentResourceFinder.java
@@ -66,11 +66,11 @@ public class SupportFragmentResourceFinder implements ResourceFinder
     {
         if (this.parent == null)
         {
+            //noinspection ConstantConditions
             ViewParent parent = this.fragment.getView().getParent();
             while (parent.getClass().getName().contains("FragmentContainerView"))
                 parent = parent.getParent();
-            //noinspection ConstantConditions
-            this.parent = (ViewGroup) this.fragment.getView().getParent();
+            this.parent = (ViewGroup) parent;
         }
         return this.parent;
     }


### PR DESCRIPTION
Now checks if the parent is a FragmentContainerView when retrieving parent in getPromptParentView

if it is it goes up levels until it finds one that isn't