### PR TITLE
Fix: FullscreenPromptBackground supports display cutout devices

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/FullscreenPromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/FullscreenPromptBackground.java
@@ -82,9 +82,9 @@ public class FullscreenPromptBackground extends PromptBackground
     public void prepare(@NonNull final PromptOptions options, final boolean clipToBounds, @NonNull Rect clipBounds)
     {
         final RectF focalBounds = options.getPromptFocal().getBounds();
-        DisplayMetrics metrics = getDisplayMetrics();
 
-        mBaseBounds.set(0, 0, metrics.widthPixels, metrics.heightPixels);
+        mBaseBounds.set(clipBounds.left, clipBounds.top, clipBounds.right, clipBounds.bottom);
+
         mFocalCentre.x = focalBounds.centerX();
         mFocalCentre.y = focalBounds.centerY();
     }


### PR DESCRIPTION
When using FullscreenPromptBackground on devices with display cutout,
such as punch hole, PromptBackground didn't fill entire screen. More
precisely some part of underlaying activity wasn't covered.

This fix is tested it on emulator, and on Samsung A51 physical device.