### PR TITLE
additional option parameter for different behavior regarding system status bar

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -220,7 +220,7 @@ public class MaterialTapTargetPrompt
 
         Rect rect = new Rect();
         resourceFinder.getPromptParentView().getWindowVisibleDisplayFrame(rect);
-        mStatusBarHeight = rect.top;
+        mStatusBarHeight = mView.mPromptOptions.getIgnoreStatusBar() ? 0 : rect.top;
 
         mGlobalLayoutListener = () -> {
             final View targetView = mView.mPromptOptions.getTargetView();

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptOptions.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptOptions.java
@@ -149,6 +149,11 @@ public class PromptOptions<T extends PromptOptions>
     private boolean mBackButtonDismissEnabled = true;
 
     /**
+     * Indicates how drawing area should be placed regarding to system status bar
+     */
+    private boolean mIgnoreStatusBar = false;
+
+    /**
      * Listener for when the prompt state changes.
      */
     @Nullable private MaterialTapTargetPrompt.PromptStateChangeListener mPromptStateChangeListener;
@@ -1398,6 +1403,30 @@ public class PromptOptions<T extends PromptOptions>
     public boolean getBackButtonDismissEnabled()
     {
         return mBackButtonDismissEnabled;
+    }
+
+    /**
+     * Indicates whether to ignore system status bar. Drawing area will be increased to the top of
+     * screen regardless of status bar if this flag is true (status bar should be transparent to see
+     * any effect from this)
+     * Default: false
+     * @param enabled true for drawing behind system status bar
+     * @return This Builder object to allow for chaining of calls to set methods
+     */
+    @NonNull
+    public T setIgnoreStatusBar(final boolean enabled)
+    {
+        mIgnoreStatusBar = enabled;
+        return (T) this;
+    }
+
+    /**
+     * Get ignore status bar flag
+     * @return true if status bar should be ignored, otherwise false
+     */
+    public boolean getIgnoreStatusBar()
+    {
+        return mIgnoreStatusBar;
     }
 
     /**


### PR DESCRIPTION
First of all thank you for such great lib!
In My project we use transparent system bar that's why I need this small change. I've added boolean flag for customizing lib behavior regarding to status bar. Now there are two types of behavior:
1. Default one when flag is false - background and animation are drawn under the status bar
![image](https://user-images.githubusercontent.com/4076098/99788987-f55ffd80-2b32-11eb-9b75-d9a38058f6e9.png)
2. The new one when flag is true - background and animation are drawn from the most top screen position ignoring status bar, so user can see background and animation behind transparent status bar
![image](https://user-images.githubusercontent.com/4076098/99789317-6ef7eb80-2b33-11eb-8376-6e95e2fd2c5d.png)

