### PR TITLE
Make PromptView and PromptView.mPromptOptions visible for testing

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -42,6 +42,7 @@ import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import uk.co.samuelwall.materialtaptargetprompt.extras.PromptOptions;
@@ -721,7 +722,8 @@ public class MaterialTapTargetPrompt
     /**
      * View used to render the tap target.
      */
-    static class PromptView extends View
+    @VisibleForTesting
+    public static class PromptView extends View
     {
         /*int padding;
         Paint paddingPaint = new Paint();
@@ -918,6 +920,13 @@ public class MaterialTapTargetPrompt
         public CharSequence getAccessibilityClassName()
         {
             return PromptView.class.getName();
+        }
+
+
+        @VisibleForTesting
+        public PromptOptions getPromptOptions()
+        {
+            return mPromptOptions;
         }
 
         /**

--- a/library/src/test/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPromptUnitTest.java
+++ b/library/src/test/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPromptUnitTest.java
@@ -23,16 +23,12 @@ import android.app.Activity;
 import android.graphics.Canvas;
 import android.graphics.RectF;
 import android.os.Build;
-import android.os.Handler;
 import android.os.IBinder;
-import androidx.annotation.NonNull;
-
 import android.os.Looper;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewParent;
-import android.view.accessibility.AccessibilityEvent;
 import android.widget.Button;
 import android.widget.FrameLayout;
 
@@ -48,7 +44,7 @@ import org.robolectric.util.ReflectionHelpers;
 
 import java.util.concurrent.TimeUnit;
 
-import kotlin.Unit;
+import androidx.annotation.NonNull;
 import uk.co.samuelwall.materialtaptargetprompt.extras.PromptFocal;
 import uk.co.samuelwall.materialtaptargetprompt.extras.PromptOptions;
 
@@ -906,6 +902,18 @@ public class MaterialTapTargetPromptUnitTest extends BaseTestStateProgress
         assertNotNull(prompt);
         prompt.show();
         assertNull(prompt.mAnimationFocalBreathing);
+    }
+
+    @Test
+    public void testGetPromptOptions()
+    {
+        String text = "Primary text";
+        MaterialTapTargetPrompt prompt = createMockBuilder(SCREEN_WIDTH, SCREEN_HEIGHT)
+                .setTarget(10, 10)
+                .setPrimaryText(text)
+                .create();
+        assertNotNull(prompt);
+        assertEquals("Texts should be equal", text, prompt.mView.getPromptOptions().getPrimaryText());
     }
 
     @Test

--- a/sample/src/androidTest/java/uk/co/samuelwall/materialtaptargetprompt/sample/MainActivityTest.java
+++ b/sample/src/androidTest/java/uk/co/samuelwall/materialtaptargetprompt/sample/MainActivityTest.java
@@ -16,11 +16,13 @@
 
 package uk.co.samuelwall.materialtaptargetprompt.sample;
 
-import androidx.test.filters.LargeTest;
-import androidx.test.rule.ActivityTestRule;
-
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
+import uk.co.samuelwall.materialtaptargetprompt.MaterialTapTargetPrompt;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -42,6 +44,9 @@ public class MainActivityTest
         // Type text and then press the button.
         onView(withId(R.id.btn_navigation_prompt))
                 .perform(click());
+        MaterialTapTargetPrompt.PromptView promptView = mActivityRule.getActivity().findViewById(uk.co.samuelwall.materialtaptargetprompt.R.id.material_target_prompt_view);
+
+        Assert.assertEquals(mActivityRule.getActivity().getString(R.string.menu_prompt_title), promptView.getPromptOptions().getPrimaryText());
 
         // Check that the text was changed.
         onView(withId(uk.co.samuelwall.materialtaptargetprompt.R.id.material_target_prompt_view))


### PR DESCRIPTION
I need the capability to test the displayed texts in espresso tests. Due to the visibility level is was not possible.