### PR TITLE
Improve text animation (#146)

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -750,12 +750,10 @@ public class MaterialTapTargetPrompt
             setId(R.id.material_target_prompt_view);
             setFocusableInTouchMode(true);
             requestFocus();
-            // Hardware acceleration for clipping to a path is not supported on SDK < 18
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2)
-            {
-                // Disable hardware acceleration
-                setLayerType(View.LAYER_TYPE_SOFTWARE, null);
-            }
+
+            // Enable Software layer so we're able to apply blending mode.
+            setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+
             /*paddingPaint.setColor(Color.GREEN);
             paddingPaint.setAlpha(100);
             itemPaint.setColor(Color.BLUE);

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptText.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptText.java
@@ -18,6 +18,8 @@ package uk.co.samuelwall.materialtaptargetprompt.extras;
 
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import androidx.annotation.ColorInt;
@@ -93,6 +95,7 @@ public class PromptText implements PromptUIElement
             mPaintPrimaryText.setAlpha(Color.alpha(primaryTextColour));
             mPaintPrimaryText.setAntiAlias(true);
             mPaintPrimaryText.setTextSize(options.getPrimaryTextSize());
+            mPaintPrimaryText.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
             PromptUtils.setTypeface(mPaintPrimaryText, options.getPrimaryTextTypeface(), options.getPrimaryTextTypefaceStyle());
             mPrimaryTextAlignment = PromptUtils.getTextAlignment(options.getResourceFinder().getResources(),
                     options.getPrimaryTextGravity(), primaryText);
@@ -104,6 +107,7 @@ public class PromptText implements PromptUIElement
             mPaintSecondaryText = new TextPaint();
             @ColorInt final int secondaryTextColour = options.getSecondaryTextColour();
             mPaintSecondaryText.setColor(secondaryTextColour);
+            mPaintSecondaryText.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
             mPaintSecondaryText.setAlpha(Color.alpha(secondaryTextColour));
             mPaintSecondaryText.setAntiAlias(true);
             mPaintSecondaryText.setTextSize(options.getSecondaryTextSize());


### PR DESCRIPTION
* Add Xfer mode to paint, so the text pixels are only drawn when the background reaches them.