### PR TITLE
Clip text using background path instead of via Xfermode to fix weird UI issues

### DIFF
--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/MaterialTapTargetPrompt.java
@@ -751,8 +751,12 @@ public class MaterialTapTargetPrompt
             setFocusableInTouchMode(true);
             requestFocus();
 
-            // Enable Software layer so we're able to apply blending mode.
-            setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+            // Hardware acceleration for clipping to a path is not supported on SDK < 18
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2)
+            {
+                // Disable hardware acceleration
+                setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+            }
 
             /*paddingPaint.setColor(Color.GREEN);
             paddingPaint.setAlpha(100);
@@ -820,7 +824,17 @@ public class MaterialTapTargetPrompt
             }
 
             //Draw the text
+            Path backgroundPath = mPromptOptions.getPromptBackground().getPath();
+            if (backgroundPath != null)
+            {
+                canvas.save();
+                canvas.clipPath(backgroundPath, Region.Op.INTERSECT);
+            }
             mPromptOptions.getPromptText().draw(canvas);
+            if (backgroundPath != null)
+            {
+                canvas.restore();
+            }
         }
 
         @Override

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptBackground.java
@@ -16,6 +16,7 @@
 
 package uk.co.samuelwall.materialtaptargetprompt.extras;
 
+import android.graphics.Path;
 import android.graphics.Rect;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
@@ -41,4 +42,11 @@ public abstract class PromptBackground implements PromptUIElement
      */
     public abstract void prepare(@NonNull final PromptOptions options,
                                  boolean clipToBounds, @NonNull Rect clipBounds);
+
+    /**
+     * @return The path of the current background, useful for clipping content
+     */
+    public Path getPath() {
+        return null;
+    }
 }

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptText.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/PromptText.java
@@ -95,7 +95,6 @@ public class PromptText implements PromptUIElement
             mPaintPrimaryText.setAlpha(Color.alpha(primaryTextColour));
             mPaintPrimaryText.setAntiAlias(true);
             mPaintPrimaryText.setTextSize(options.getPrimaryTextSize());
-            mPaintPrimaryText.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
             PromptUtils.setTypeface(mPaintPrimaryText, options.getPrimaryTextTypeface(), options.getPrimaryTextTypefaceStyle());
             mPrimaryTextAlignment = PromptUtils.getTextAlignment(options.getResourceFinder().getResources(),
                     options.getPrimaryTextGravity(), primaryText);
@@ -107,7 +106,6 @@ public class PromptText implements PromptUIElement
             mPaintSecondaryText = new TextPaint();
             @ColorInt final int secondaryTextColour = options.getSecondaryTextColour();
             mPaintSecondaryText.setColor(secondaryTextColour);
-            mPaintSecondaryText.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
             mPaintSecondaryText.setAlpha(Color.alpha(secondaryTextColour));
             mPaintSecondaryText.setAntiAlias(true);
             mPaintSecondaryText.setTextSize(options.getSecondaryTextSize());

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/CirclePromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/CirclePromptBackground.java
@@ -19,6 +19,7 @@ package uk.co.samuelwall.materialtaptargetprompt.extras.backgrounds;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.Path;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
@@ -72,6 +73,11 @@ public class CirclePromptBackground extends PromptBackground
     Paint pointPaint = new Paint();*/
 
     /**
+     * The current path of the background (useful for clipping)
+     */
+    Path mPath;
+
+    /**
      * Constructor.
      */
     public CirclePromptBackground()
@@ -80,6 +86,7 @@ public class CirclePromptBackground extends PromptBackground
         mPaint.setAntiAlias(true);
         mPosition = new PointF();
         mBasePosition = new PointF();
+        mPath = new Path();
         /*pointPaint.setColor(Color.RED);
         pointPaint.setAlpha(100);*/
     }
@@ -212,6 +219,8 @@ public class CirclePromptBackground extends PromptBackground
         // Change the current centre position to be a position scaled from the focal to the base.
         mPosition.set(focalCentreX + ((mBasePosition.x - focalCentreX) * revealModifier),
                 focalCentreY + ((mBasePosition.y - focalCentreY) * revealModifier));
+        mPath.reset();
+        mPath.addCircle(mPosition.x, mPosition.y, mRadius, Path.Direction.CW);
     }
 
     @Override
@@ -234,5 +243,11 @@ public class CirclePromptBackground extends PromptBackground
     public boolean contains(float x, float y)
     {
         return PromptUtils.isPointInCircle(x, y, mPosition, mRadius);
+    }
+
+    @Override
+    public Path getPath()
+    {
+        return mPath;
     }
 }

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/FullscreenPromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/FullscreenPromptBackground.java
@@ -20,6 +20,7 @@ import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.Path;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
@@ -41,6 +42,7 @@ public class FullscreenPromptBackground extends PromptBackground
     int mBaseColourAlpha;
     float mRx, mRy;
     PointF mFocalCentre;
+    Path mPath;
 
     /**
      * Constructor.
@@ -52,6 +54,7 @@ public class FullscreenPromptBackground extends PromptBackground
         mBounds = new RectF();
         mBaseBounds = new RectF();
         mFocalCentre = new PointF();
+        mPath = new Path();
         mRx = mRy = 0;
     }
 
@@ -100,6 +103,8 @@ public class FullscreenPromptBackground extends PromptBackground
     {
         mPaint.setAlpha((int) (mBaseColourAlpha * alphaModifier));
         PromptUtils.scale(mFocalCentre, mBaseBounds, mBounds, revealModifier, false);
+        mPath.reset();
+        mPath.addRect(mBounds, Path.Direction.CW);
     }
 
     @Override
@@ -112,5 +117,11 @@ public class FullscreenPromptBackground extends PromptBackground
     public boolean contains(float x, float y)
     {
         return mBounds.contains(x, y);
+    }
+
+    @Override
+    public Path getPath()
+    {
+        return mPath;
     }
 }

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/RectanglePromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/RectanglePromptBackground.java
@@ -20,6 +20,7 @@ import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.Path;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
@@ -40,7 +41,7 @@ public class RectanglePromptBackground extends PromptBackground
     int mBaseColourAlpha;
     float mRx, mRy;
     PointF mFocalCentre;
-
+    Path mPath;
     /**
      * Constructor.
      */
@@ -110,6 +111,8 @@ public class RectanglePromptBackground extends PromptBackground
     {
         mPaint.setAlpha((int) (mBaseColourAlpha * alphaModifier));
         PromptUtils.scale(mFocalCentre, mBaseBounds, mBounds, revealModifier, false);
+        mPath.reset();
+        mPath.addRoundRect(mBounds, mRx, mRy, Path.Direction.CW);
     }
 
     @Override
@@ -122,5 +125,11 @@ public class RectanglePromptBackground extends PromptBackground
     public boolean contains(float x, float y)
     {
         return mBounds.contains(x, y);
+    }
+
+    @Override
+    public Path getPath()
+    {
+        return mPath;
     }
 }

--- a/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/RectanglePromptBackground.java
+++ b/library/src/main/java/uk/co/samuelwall/materialtaptargetprompt/extras/backgrounds/RectanglePromptBackground.java
@@ -52,6 +52,7 @@ public class RectanglePromptBackground extends PromptBackground
         mBounds = new RectF();
         mBaseBounds = new RectF();
         mFocalCentre = new PointF();
+        mPath = new Path();
         final float density = Resources.getSystem().getDisplayMetrics().density;
         mRx = mRy = 2 * density;
     }


### PR DESCRIPTION
To fix #201 I propose a better way to clip the text and fix the weird rendering. Not using Xfermode on the Text, but to expose the path of a Background, and use the path in clipping while rendering. This also makes it possible to use HW accelerated view instead of software, so performance should als be better.

This fixes the issues from #201, #146