### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 
 org.gradle.jvmargs=-Xmx6g -XX:ReservedCodeCacheSize=2g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
-org.gradle.configureondemand=false
+org.gradle.configureondemand=true
 org.gradle.caching=true
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION

[Configuration on demand](https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:configuration_on_demand). Configuration on demand tells Gradle to configure modules that only are relevant to the requested tasks instead of configuring all of them. We can enable this feature by setting `org.gradle.configureondemand=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
